### PR TITLE
Change `Mod` initialization to not break when loading a HEW-built pat…

### DIFF
--- a/SharpTune/Program.cs
+++ b/SharpTune/Program.cs
@@ -22,11 +22,17 @@ using SharpTune.EcuMapTools;
 using System.Text;
 using EcuMapTools;
 using SharpTuneCore;
+using System.Runtime.InteropServices;
 
 namespace SharpTune
 {
     public static class Program
     {
+        // defines for commandline output
+        [DllImport("kernel32.dll")]
+        static extern bool AttachConsole(int dwProcessId);
+        private const int ATTACH_PARENT_PROCESS = -1;
+
         private static SharpTuner sharpTuner;
         /// <summary>
         /// Entry point.  Runs the utility with or without exception handling, depending on whether a debugger is attached.
@@ -45,6 +51,9 @@ namespace SharpTune
             {
                 try
                 {
+                    // redirect console output to parent process;
+                    // must be before any calls to Console.WriteLine()
+                    AttachConsole(ATTACH_PARENT_PROCESS);
                     result = Run(args);
                 }
                 catch (Exception exception)

--- a/SharpTune/RomMod/Mod.cs
+++ b/SharpTune/RomMod/Mod.cs
@@ -211,8 +211,8 @@ namespace SharpTune.RomMod
             FilePath = modPath;
             isResource = false;
             reader = new SRecordReader(modPath);
-            TryReadPatches();
-            TryReversePatches();
+            //TryReadPatches();
+            //TryReversePatches();
         }
 
         public bool TryDefinition(AvailableDevices ad, string defPath)

--- a/SharpTune/RomMod/ModDefinition.cs
+++ b/SharpTune/RomMod/ModDefinition.cs
@@ -352,7 +352,7 @@ namespace SharpTune.RomMod
                     }
 
                     char[] splitter = { '\0' };
-                    string tempstring = System.Text.Encoding.ASCII.GetString(tempbytelist.ToArray());
+                    string tempstring = System.Text.Encoding.UTF8.GetString(tempbytelist.ToArray());
                     metaString = tempstring.Split(splitter)[0];
                     return true;
                 }

--- a/SharpTune/RomMod/RomMod.cs
+++ b/SharpTune/RomMod/RomMod.cs
@@ -240,6 +240,9 @@ namespace SharpTune.RomMod
                     return false;
                 }
             }
+
+            // use baseline'd patch to create new mod
+            mod = new Mod(mod.ModIdent + ".patch");
             File.Copy(romPath, "oem.bin", true);
             Trace.WriteLine("Attempting to test patches");
             if (!mod.TryCheckApplyMod(romPath, romPath, true, false)) //&& !mod.TryCheckApplyMod(romPath, romPath, false, false)) ;


### PR DESCRIPTION
…ch before baselining.

Update `TryHewBuild` to use patch generated after baselining for verification.
Update `TryReadDefString` to use UTF8 encoding instead of ASCII.